### PR TITLE
Add vSphere VM configuration for blalba in labul

### DIFF
--- a/blalba-labul/README.md
+++ b/blalba-labul/README.md
@@ -1,0 +1,5 @@
+# blalba vm
+
+## CREATE
+
+## DESTROY

--- a/blalba-labul/ansible/requirements.yaml
+++ b/blalba-labul/ansible/requirements.yaml
@@ -1,0 +1,24 @@
+---
+collections:
+  - name: ansible.netcommon
+    version: 8.0.1
+  - name: ansible.posix
+    version: 2.1.0
+  - name: awx.awx
+    version: 24.6.1
+  - name: community.crypto
+    version: 3.0.3
+  - name: community.docker
+    version: 4.7.0
+  - name: community.general
+    version: 12.1.0
+  - name: community.hashi_vault
+    version: 7.0.0
+  - name: community.vmware
+    version: 5.7.2
+  - name: kubernetes.core
+    version: 6.0.0
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-25.5.816.tar.gz/sthings-container-25.5.816.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-25.3.760.tar.gz/sthings-baseos-25.3.760.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-25.4.506.tar.gz/sthings-awx-25.4.506.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-25.1.991.tar.gz/sthings-rke-25.1.991.tar.gz

--- a/blalba-labul/execution.yaml
+++ b/blalba-labul/execution.yaml
@@ -1,0 +1,11 @@
+---
+operation: apply
+variables:
+  - vault_addr=https://vault-vsphere.tiab.labda.sva.de:8200
+ansiblePlaybooks:
+  - "sthings.baseos.setup"
+ansibleParameters: []
+ansibleInventoryType: default
+ansibleWaitTimeout: 30
+ansibleRequirementsFile: tests/vm/requirements.yaml
+encryptedFile: ""

--- a/blalba-labul/vm.tf
+++ b/blalba-labul/vm.tf
@@ -1,0 +1,52 @@
+module "blalba" {
+  source   = "github.com/stuttgart-things/vsphere-vm?ref=v1.7.5-2.7.0"
+  vm_count = 1
+  vsphere_vm_name = "blalba"
+  vm_memory = 8192
+  vsphere_vm_template = "sthings-u24"
+  vm_disk_size = "64"
+  vm_num_cpus = 8
+  firmware = "bios"
+  vsphere_vm_folder_path = "stuttgart-things/production"
+  vsphere_datacenter = "/LabUL"
+  vsphere_datastore = "/LabUL/datastore/UL-ESX-SAS-01"
+  vsphere_resource_pool = "/LabUL/host/Cluster-V6.5/Resources"
+  vsphere_network = "/LabUL/network/LAB-10.31.103"
+  bootstrap = ["echo STUTTGART-THINGS"]
+  annotation = "VSPHERE-VM blalba sthings-u24 BUILD w/ TERRAFORM FOR STUTTGART-THINGS"
+  vsphere_server   = var.vsphere_server
+  vsphere_user     = var.vsphere_user
+  vsphere_password = var.vsphere_password
+  vm_ssh_user      = var.vm_ssh_user
+  vm_ssh_password  = var.vm_ssh_password
+}
+variable "vsphere_server" {
+  type        = string
+  description = "name of vsphere vm server"
+}
+
+variable "vm_ssh_user" {
+  type        = string
+  description = "username of ssh user for vm"
+}
+
+variable "vm_ssh_password" {
+  type        = string
+  description = "password of ssh user"
+  sensitive   = true
+}
+
+variable "vsphere_user" {
+  type        = string
+  description = "username of vsphere user"
+}
+
+variable "vsphere_password" {
+  type        = string
+  description = "password of vsphere user"
+  sensitive   = true
+}
+
+output "ip" {
+  value = [module.blalba.ip]
+}


### PR DESCRIPTION
This PR adds the rendered vSphere VM configuration for blalba in labul environment.

Environment: labul
VM Name: blalba
VM Count: 1
Resources: 8 vCPU, 8192 MB RAM, 64 GB Disk