### PR TITLE
Add vSphere VM configuration for devrke2 in labul

### DIFF
--- a/devrke2-labul/README.md
+++ b/devrke2-labul/README.md
@@ -1,0 +1,5 @@
+# devrke2 vm
+
+## CREATE
+
+## DESTROY

--- a/devrke2-labul/ansible/requirements.yaml
+++ b/devrke2-labul/ansible/requirements.yaml
@@ -1,0 +1,24 @@
+---
+collections:
+  - name: ansible.netcommon
+    version: 8.0.1
+  - name: ansible.posix
+    version: 2.1.0
+  - name: awx.awx
+    version: 24.6.1
+  - name: community.crypto
+    version: 3.0.3
+  - name: community.docker
+    version: 4.7.0
+  - name: community.general
+    version: 12.1.0
+  - name: community.hashi_vault
+    version: 7.0.0
+  - name: community.vmware
+    version: 5.7.2
+  - name: kubernetes.core
+    version: 6.0.0
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-25.5.816.tar.gz/sthings-container-25.5.816.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-25.3.760.tar.gz/sthings-baseos-25.3.760.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-25.4.506.tar.gz/sthings-awx-25.4.506.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-25.1.991.tar.gz/sthings-rke-25.1.991.tar.gz

--- a/devrke2-labul/execution.yaml
+++ b/devrke2-labul/execution.yaml
@@ -1,0 +1,11 @@
+---
+operation: apply
+variables:
+  - vault_addr=https://vault-vsphere.tiab.labda.sva.de:8200
+ansiblePlaybooks:
+  - "sthings.baseos.setup"
+ansibleParameters: []
+ansibleInventoryType: default
+ansibleWaitTimeout: 30
+ansibleRequirementsFile: tests/vm/requirements.yaml
+encryptedFile: ""

--- a/devrke2-labul/vm.tf
+++ b/devrke2-labul/vm.tf
@@ -1,0 +1,58 @@
+module "devrke2" {
+  source   = "github.com/stuttgart-things/vsphere-vm?ref=v1.7.5-2.7.0"
+  vm_count = 1
+  vsphere_vm_name = "devrke2"
+  vm_memory = 8192
+  vsphere_vm_template = "sthings-u24"
+  vm_disk_size = "64"
+  vm_num_cpus = 8
+  firmware = "bios"
+  vsphere_vm_folder_path = "stuttgart-things/testing"
+  vsphere_datacenter = "/LabUL"
+  vsphere_datastore = "/LabUL/datastore/ESX02-Local1"
+  vsphere_resource_pool = "/LabUL/host/Cluster-V6.7/Resources"
+  vsphere_network = "/LabUL/network/LAB-10.31.102"
+  bootstrap = ["echo STUTTGART-THINGS"]
+  annotation = "VSPHERE-VM devrke2 sthings-u24 BUILD w/ TERRAFORM FOR STUTTGART-THINGS"
+  vsphere_server   = data.vault_kv_secret_v2.vsphere.data["ip"]
+  vsphere_user     = data.vault_kv_secret_v2.vsphere.data["username"]
+  vsphere_password = data.vault_kv_secret_v2.vsphere.data["password"]
+  vm_ssh_user      = data.vault_kv_secret_v2.vsphere.data["vm_ssh_user"]
+  vm_ssh_password  = data.vault_kv_secret_v2.vsphere.data["vm_ssh_password"]
+}
+
+output "ip" {
+  value = [module.devrke2.ip]
+}
+provider "vault" {
+  address = var.vault_addr
+
+  auth_login {
+    path = "auth/approle/login"
+    parameters = {
+      role_id   = var.vault_role_id
+      secret_id = var.vault_secret_id
+    }
+  }
+}
+
+data "vault_kv_secret_v2" "vsphere" {
+  mount = "cloud"
+  name  = "vsphere-labul"
+}
+
+variable "vault_addr" {
+  type        = string
+  description = "Vault server address"
+}
+
+variable "vault_role_id" {
+  type        = string
+  description = "AppRole Role ID"
+}
+
+variable "vault_secret_id" {
+  type        = string
+  description = "AppRole Secret ID"
+  sensitive   = true
+}


### PR DESCRIPTION
This PR adds the rendered vSphere VM configuration for devrke2 in labul environment.

Environment: labul
VM Name: devrke2
VM Count: 1
Resources: 8 vCPU, 8192 MB RAM, 64 GB Disk