### PR TITLE
Add volumeclaim-simple claim - test-claim

### DIFF
--- a/claims/claims/volumeclaim-simple.yaml
+++ b/claims/claims/volumeclaim-simple.yaml
@@ -1,0 +1,16 @@
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: VolumeClaim
+metadata:
+  name: simple-storage
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  annotations:
+    description: A simple persistent volume claim for application data
+  namespace: default
+  providerConfigRef: default-k8s
+  pvcName: app-data
+  storage: '20Gi'
+  storageClassName: standard
+  volumeMode: Filesystem


### PR DESCRIPTION
## Claim Manifest Created via Backstage

**Template**: volumeclaim-simple
**Claim Name**: test-claim

### Manifest Details
```yaml
apiVersion: resources.stuttgart-things.com/v1alpha1
kind: VolumeClaim
metadata:
  name: simple-storage
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  annotations:
    description: A simple persistent volume claim for application data
  namespace: default
  providerConfigRef: default-k8s
  pvcName: app-data
  storage: '20Gi'
  storageClassName: standard
  volumeMode: Filesystem

```

Created automatically via Backstage Claim Machinery integration.
