### PR TITLE
chore: replace dagger init boilerplate with real module docs

### DIFF
--- a/crossplane-configuration/main.go
+++ b/crossplane-configuration/main.go
@@ -1,16 +1,6 @@
-// A generated module for CrossplaneConfiguration functions
-//
-// This module has been generated via dagger init and serves as a reference to
-// basic module structure as you get started with Dagger.
-//
-// Two functions have been pre-created. You can modify, delete, or add to them,
-// as needed. They demonstrate usage of arguments and return types using simple
-// echo and grep commands. The functions can be called from the dagger CLI or
-// from one of the SDKs.
-//
-// The first line in this comment block is a short description line and the
-// rest is a long description with more detail on the module's purpose or usage,
-// if appropriate. All modules should have a short description.
+// CrossplaneConfiguration module generates Crossplane package configurations
+// (XRD, Composition, Configuration) with flexible variable management via
+// defaults files, variable files and CLI overrides. See README.md for usage.
 
 package main
 

--- a/kubernetes-deployment/main.go
+++ b/kubernetes-deployment/main.go
@@ -1,16 +1,7 @@
-// A generated module for KubernetesDeployment functions
-//
-// This module has been generated via dagger init and serves as a reference to
-// basic module structure as you get started with Dagger.
-//
-// Two functions have been pre-created. You can modify, delete, or add to them,
-// as needed. They demonstrate usage of arguments and return types using simple
-// echo and grep commands. The functions can be called from the dagger CLI or
-// from one of the SDKs.
-//
-// The first line in this comment block is a short description line and the
-// rest is a long description with more detail on the module's purpose or usage,
-// if appropriate. All modules should have a short description.
+// KubernetesDeployment module bundles Helm/Helmfile rendering and apply,
+// raw manifest application, KCL-based deployments, CRD installation, Flux
+// bootstrap/render/apply/destroy workflows and SOPS-secret helpers used to
+// roll out workloads against a Kubernetes cluster. See README.md for usage.
 
 package main
 

--- a/presentations/main.go
+++ b/presentations/main.go
@@ -1,16 +1,6 @@
-// A generated module for Presentations functions
-//
-// This module has been generated via dagger init and serves as a reference to
-// basic module structure as you get started with Dagger.
-//
-// Two functions have been pre-created. You can modify, delete, or add to them,
-// as needed. They demonstrate usage of arguments and return types using simple
-// echo and grep commands. The functions can be called from the dagger CLI or
-// from one of the SDKs.
-//
-// The first line in this comment block is a short description line and the
-// rest is a long description with more detail on the module's purpose or usage,
-// if appropriate. All modules should have a short description.
+// Presentations module scaffolds and serves Hugo-based presentation sites:
+// initialize a new site from templates, add agenda/content sections and run
+// a local development server. See README.md for usage.
 
 package main
 


### PR DESCRIPTION
## Summary
- Replaces the leftover `dagger init` boilerplate doc comments in `crossplane-configuration/main.go`, `kubernetes-deployment/main.go` and `presentations/main.go` with concise descriptions of what the modules actually do.

Refs #143 (P3 — hygiene).

## Test plan
- [ ] CI passes
- [ ] `dagger functions -m <module>` still lists the same functions (doc-only change above the `package main` line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)