### PR TITLE
fix(deps): pick up dagger v0.112.0 cache-bust fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Blueprints** is a collection of modular, reusable Dagger pipelines for automating build, test, and deployment workflows in modern DevOps environments.
 
+> Dagger engine: **v0.20.8** · sub-module pins: **v0.112.0** (see each `dagger.json`).
+
 ## Overview
 
 These blueprints are designed for platform engineers, SREs, and developers who want to accelerate CI/CD, infrastructure automation, and code quality gates using Dagger.


### PR DESCRIPTION
## Summary

Real-diff replacement for #160. Adds a one-line engine/version note to the top-level README and uses a `fix(deps):` subject so semantic-release tags this as v2.1.4.

## Why

#159 was squashed onto main with a `chore:` subject — angular preset filters that out, no tag. #160 was an `--allow-empty` follow-up; GitHub's squash-merge silently dropped the empty commit (mergeCommit oid was the same SHA as #159's). semantic-release still sees one commit since v2.1.3, classified `chore:` → no release.

This PR has a real diff (one line added to README.md noting `Dagger engine: v0.20.8 · sub-module pins: v0.112.0`), so the squash actually lands on main and `commit-analyzer` sees a `fix:` and cuts a patch tag.

The functional pickup is unchanged from #159: stuttgart-things/dagger#267 — `gh repo clone` + `git fetch origin --force` no longer cached across runs in `CloneGithub` / `AddFolderToGithubBranch`. Resolves the "fetch first" push rejection in `argocd/bootstrap-clusterbook-cluster` and `vm/executeAnsibleEncryptAndCommit`.

## Test plan

- [ ] After squash-merge to main, run `semantic-release --no-ci` (or let CI fire) — expect a v2.1.4 tag and a fresh CHANGELOG.md entry.
- [ ] Validation that the cache-bust actually works (still pending after the tag): two consecutive `argocd/bootstrap-clusterbook-cluster` runs on one runner with a fresh `origin/main` commit between them, both succeed without manual `dagger core engine local-cache prune`. Dagger Cloud trace should show `gh repo clone` + `git fetch` no longer marked CACHED on run #2.

Closes #158. Supersedes #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)