### PR TITLE
feat(argocd): cacheBuster arg on bootstrap + create-vault-issuer

### DIFF
--- a/argocd/bootstrap.go
+++ b/argocd/bootstrap.go
@@ -156,7 +156,20 @@ func (m *Argocd) BootstrapClusterbookCluster(
 	// +optional
 	// +default="squash"
 	mergeMethod string,
+
+	// --- Cache control ---
+
+	// Arbitrary string mixed into the function-level cache key. Pass a
+	// timestamp (e.g. `date +%s%N`) from CI to force a fresh execution
+	// when the function's other args are deterministic but the side
+	// effects (git push, kubectl apply) must replay. Inner CACHE_BUSTER
+	// env vars on individual containers don't help here — Dagger short-
+	// circuits the whole function on input-hash match before any
+	// container in the body is instantiated.
+	// +optional
+	cacheBuster string,
 ) (*dagger.File, error) {
+	_ = cacheBuster
 	if detectNetworkKey && networkKey == "" {
 		if kubeConfig == nil {
 			return nil, fmt.Errorf("detect-network-key=true requires --kube-config")

--- a/argocd/create_vault_issuer.go
+++ b/argocd/create_vault_issuer.go
@@ -99,7 +99,18 @@ func (m *Argocd) CreateVaultIssuer(
 	// +optional
 	// +default="8760h"
 	tokenTtl string,
+
+	// Arbitrary string mixed into the function-level cache key. Pass a
+	// timestamp (e.g. `date +%s%N`) from CI to force a fresh execution
+	// when the function's other args are deterministic but the side
+	// effects (Vault token mint, kubectl apply) must replay. Inner
+	// CACHE_BUSTER env vars on individual containers don't help here —
+	// Dagger short-circuits the whole function on input-hash match
+	// before any container in the body is instantiated.
+	// +optional
+	cacheBuster string,
 ) (string, error) {
+	_ = cacheBuster
 	if clusterName == "" {
 		return "", fmt.Errorf("cluster-name is required")
 	}


### PR DESCRIPTION
## Summary
- Adds optional `cacheBuster string` arg to `BootstrapClusterbookCluster` and `CreateVaultIssuer`
- Closes the function-level cache trap described in #168 — inner `CACHE_BUSTER` env vars on individual containers (added in #158 / [dagger#267](https://github.com/stuttgart-things/dagger/pull/267)) are dead code when the outer function returns cached on input-hash match
- Witnessed in [stuttgart-things#2169](https://github.com/stuttgart-things/stuttgart-things/pull/2169) → the bootstrap step's commit-back returned `CACHED [0.8s]`, rendered manifests never reached the PR branch, manually restored via [stuttgart-things#2170](https://github.com/stuttgart-things/stuttgart-things/pull/2170)

## Why this shape (option 1 from #168)
Dagger caches each function's return value on input-hash match and skips the body entirely on a hit — none of the side-effecting containers (`AddFolderToGithubBranch`, `Kubectl`, Vault HTTP) ever instantiate. An input arg that varies per call is the only thing that punches through; default `""` keeps tests / local usage cache-friendly.

The architectural split (option 3 — separate pure render from impure push) is cleaner but bigger; this PR is the minimum-blast-radius patch. We can layer the split on later if needed.

## Caller wiring (follow-up — not this PR)
Workflow templates in `stuttgart-things/github-workflow-templates` need a one-line append per call site:
```bash
ARGS+=(--cache-buster "$(date +%s%N)")
```
Affected workflows:
- `call-argocd-bootstrap.yaml`
- `call-create-vault-issuer.yaml`

I'll open that PR after this lands and v2.3.0 is published.

## Test plan
- [x] `dagger develop` regenerates `dagger.gen.go` with the new arg
- [x] `dagger call -m argocd bootstrap-clusterbook-cluster --help` shows `--cache-buster`
- [x] `dagger call -m argocd create-vault-issuer --help` shows `--cache-buster`
- [ ] Workflow template PR threads `--cache-buster "$(date +%s%N)"` through both call-sites
- [ ] Re-register a cluster twice in a row (e.g. decom + re-add) — Bootstrap step's commit-back fires on both runs (no `CACHED` on the function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)