### PR TITLE
fix(argocd): bump default KCL module to clusterbook-cluster-gen:0.3.0

### DIFF
--- a/argocd/bootstrap.go
+++ b/argocd/bootstrap.go
@@ -29,7 +29,7 @@ func (m *Argocd) BootstrapClusterbookCluster(
 	valuesFile *dagger.File,
 	// OCI KCL module source
 	// +optional
-	// +default="ghcr.io/stuttgart-things/clusterbook-cluster-gen:0.1.0"
+	// +default="ghcr.io/stuttgart-things/clusterbook-cluster-gen:0.3.0"
 	ociSource string,
 	// Argo CD-side cluster name
 	// +optional

--- a/argocd/render.go
+++ b/argocd/render.go
@@ -31,7 +31,7 @@ func (m *Argocd) RenderClusterbookClusterConfig(
 	valuesFile *dagger.File,
 	// OCI KCL module source
 	// +optional
-	// +default="ghcr.io/stuttgart-things/clusterbook-cluster-gen:0.1.0"
+	// +default="ghcr.io/stuttgart-things/clusterbook-cluster-gen:0.3.0"
 	ociSource string,
 	// Argo CD-side cluster name; defaults to name when neither is set via file
 	// +optional


### PR DESCRIPTION
## Summary
- Bumps `+default=` for `ociSource` in `BootstrapClusterbookCluster` and `RenderClusterbookClusterConfig` from `clusterbook-cluster-gen:0.1.0` → `clusterbook-cluster-gen:0.3.0`
- 0.1.0 predates kind-cluster support, `kubeconfigSecretRef.key`, and the `clusterAnnotations` passthrough — every live caller has been overriding via `--oci-source` because 0.1.0 silently drops the new fields
- Backward-compatible: `task test-bootstrap-clusterbook-cluster` renders the classic philly cluster identically against 0.3.0 (verified locally)

## Note on #155
The original issue asked to rename the module from `clusterbook-cluster-gen` → `clusterbook-cluster` (drop the `-gen`). That rename never happened — the published OCI artifact stayed `clusterbook-cluster-gen` (currently at `0.3.0`). This PR addresses the spirit of the ask (the stale default) while keeping the actual module name. Closes #155.

## Test plan
- [x] `task test-bootstrap-clusterbook-cluster` (classic philly render) passes against new default
- [ ] Smoke-test on next cluster registration that omits `--oci-source` (e.g. a fresh kind cluster from Backstage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)