### PR TITLE
fix(argocd): rename CreateVaultK8sAuth → CreateVaultKubernetesAuth

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -14,7 +14,7 @@ helpers live in the [`secrets`](../secrets/README.md) module.
 | `apply-config` | Apply a rendered config file to a cluster (creates the target namespace first). |
 | `commit-config` | Commit a rendered file to a Git repo at `<destinationPath>/<fileName>` on a branch; optionally open a PR against a base branch and optionally merge it. |
 | `create-vault-issuer` | Prepare the cluster-side prerequisites cert-manager needs to authenticate against a remote Vault PKI: applies the policy + mints a token in Vault directly (HTTP API), reads the CA, then `kubectl apply`s a 3-document YAML (Namespace + 2 Secrets) directly to the target cluster using the supplied kubeconfig. Does NOT create the `ClusterIssuer` itself — that's the `cert-manager-vault-pki` AppSet's job. Closes #162. |
-| `create-vault-k8s-auth` | Provision a Vault Kubernetes auth backend for an in-cluster ServiceAccount (typically ESO): `kubectl apply`s a 4-document YAML (Namespace + ServiceAccount + non-expiring SA-token Secret + ClusterRoleBinding→`system:auth-delegator`) to the target cluster, then drives Vault HTTP directly to mount `auth/<cluster-name>-<auth-name>`, write its config (`kubernetes_host` + reviewer JWT + CA + `disable_iss_validation=true` + `disable_local_ca_jwt=true`), and upsert a role binding the SA to one or more pre-existing policies. Replaces the Terraform path in `argocd/clusters/<cluster>/vault-k8s-auth/`. |
+| `create-vault-kubernetes-auth` | Provision a Vault Kubernetes auth backend for an in-cluster ServiceAccount (typically ESO): `kubectl apply`s a 4-document YAML (Namespace + ServiceAccount + non-expiring SA-token Secret + ClusterRoleBinding→`system:auth-delegator`) to the target cluster, then drives Vault HTTP directly to mount `auth/<cluster-name>-<auth-name>`, write its config (`kubernetes_host` + reviewer JWT + CA + `disable_iss_validation=true` + `disable_local_ca_jwt=true`), and upsert a role binding the SA to one or more pre-existing policies. Replaces the Terraform path in `argocd/clusters/<cluster>/vault-k8s-auth/`. |
 | `bootstrap-clusterbook-cluster` | Orchestrator: render → optional `--deploy` → optional `--commit-to-git`. Returns the rendered file. |
 
 The functions are designed to compose: `render-clusterbook-cluster-config`
@@ -336,7 +336,7 @@ kubectl get clusterissuer vault-pki
 
 ## Create Vault Kubernetes auth backend (for ESO)
 
-`create-vault-k8s-auth` provisions everything an in-cluster
+`create-vault-kubernetes-auth` provisions everything an in-cluster
 ServiceAccount needs to authenticate to a remote Vault and consume one
 or more pre-existing policies. It's the Dagger-native replacement for
 the `argocd/clusters/<cluster>/vault-k8s-auth/` Terraform module
@@ -413,7 +413,7 @@ write roles (typically the admin token, same one used for
 ```bash
 # CREATE — minimal call (defaults: auth-name=eso, namespace=external-secrets,
 # policy=read-homerun2-pr, token-ttl=3600)
-dagger call -m argocd create-vault-k8s-auth \
+dagger call -m argocd create-vault-kubernetes-auth \
   --cluster-name homerun2-dev \
   --kubeconfig-source-file secrets/kubeconfigs/homerun2-dev.yaml \
   --vault-env-file secrets/envs/vault-infra-labul.enc.yaml \
@@ -423,7 +423,7 @@ dagger call -m argocd create-vault-k8s-auth \
 
 ```bash
 # CREATE — multiple policies, custom TTL
-dagger call -m argocd create-vault-k8s-auth \
+dagger call -m argocd create-vault-kubernetes-auth \
   --cluster-name homerun2-dev \
   --kubeconfig-source-file secrets/kubeconfigs/homerun2-dev.yaml \
   --vault-env-file secrets/envs/vault-infra-labul.enc.yaml \
@@ -435,7 +435,7 @@ dagger call -m argocd create-vault-k8s-auth \
 
 ```bash
 # CREATE — different cluster + per-cluster policy + non-default SA
-dagger call -m argocd create-vault-k8s-auth \
+dagger call -m argocd create-vault-kubernetes-auth \
   --cluster-name foo-dev \
   --kubeconfig-source-file secrets/kubeconfigs/foo-dev.yaml \
   --vault-env-file secrets/envs/vault-infra-labul.enc.yaml \

--- a/argocd/create_vault_k8s_auth.go
+++ b/argocd/create_vault_k8s_auth.go
@@ -25,7 +25,7 @@ type kubeconfigShape struct {
 	} `yaml:"clusters"`
 }
 
-// CreateVaultK8sAuth provisions the cluster-side prerequisites and the
+// CreateVaultKubernetesAuth provisions the cluster-side prerequisites and the
 // Vault-side Kubernetes auth backend an in-cluster ServiceAccount uses
 // to authenticate to Vault and consume one or more pre-existing
 // policies. Mirrors the layout in CreateVaultIssuer: decrypt SOPS
@@ -58,7 +58,7 @@ type kubeconfigShape struct {
 //
 // Idempotent: re-runs upsert the config + role and skip the auth-mount
 // step when the path is already in use.
-func (m *Argocd) CreateVaultK8sAuth(
+func (m *Argocd) CreateVaultKubernetesAuth(
 	ctx context.Context,
 	// Target cluster name; prefixes the Vault auth backend path
 	// (`<cluster-name>-<auth-name>`).


### PR DESCRIPTION
## Summary

Dagger's kebab-case conversion of `K8s` produces `k-8-s`, not `k8s`, so
the function `CreateVaultK8sAuth` exposed as CLI `create-vault-k-8-s-auth`
instead of the documented `create-vault-k8s-auth`. The reusable workflow
[`call-create-vault-k8s-auth.yaml`](https://github.com/stuttgart-things/github-workflow-templates/blob/main/.github/workflows/call-create-vault-k8s-auth.yaml)
called the documented name and got:

```
Error: unknown command "create-vault-k8s-auth" for "dagger call"
```

Witnessed in [stuttgart-things#2247 run 26497548726 job](https://github.com/stuttgart-things/stuttgart-things/actions/runs/26497548726/job/78029587789).

Renaming `CreateVaultK8sAuth` → `CreateVaultKubernetesAuth` yields a clean
kebab name `create-vault-kubernetes-auth`, parallel to the existing
`create-vault-issuer`. Updates the 5 README CLI examples to match.

## Test plan

- [ ] Semantic-release tags v2.4.1 on merge
- [ ] `dagger functions -m github.com/stuttgart-things/blueprints/argocd@v2.4.1` lists `create-vault-kubernetes-auth`
- [ ] Bump default `argocd-module-version` in `github-workflow-templates/.github/workflows/call-create-vault-k8s-auth.yaml` to v2.4.1 + change `args:` to `create-vault-kubernetes-auth`
- [ ] Re-run stuttgart-things#2247 and confirm Create-Vault-K8s-Auth job passes