### PR TITLE
fix(vm): sync collection pins to canonical list, drop dead release asset globs

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -21,19 +21,11 @@
         "changelogFile": "CHANGELOG.md"
       }
     ],
-    [
-      "@semantic-release/github",
-      {
-        "assets": [
-          "dist/**/*.{go,mod,sum}",
-          "docs/**/*.{pdf,md}"
-        ]
-      }
-    ],
+    "@semantic-release/github",
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "go.mod", "go.sum"],
+        "assets": ["CHANGELOG.md"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]

--- a/tests/vm/ansible/requirements.yaml
+++ b/tests/vm/ansible/requirements.yaml
@@ -23,6 +23,6 @@ collections:
   - name: kubernetes.core
     version: 6.5.0
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.812.1209/sthings-awx-26.812.1209.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.820.1251/sthings-container-26.820.1251.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.821.1257/sthings-container-26.821.1257.tar.gz
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.730.1176/sthings-rke-26.730.1176.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.821.1252/sthings-baseos-26.821.1252.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.821.1259/sthings-baseos-26.821.1259.tar.gz

--- a/tests/vm/ansible/requirements.yaml
+++ b/tests/vm/ansible/requirements.yaml
@@ -1,24 +1,28 @@
 ---
+# Kept in sync with stuttgart-things/ansible requirements.yaml, which is the
+# canonical consumer-facing pin list. This copy is live config, not just a
+# fixture: configuration/vsphere-vm.go defaults to tests/vm/execution-vars.yaml
+# on main, and that file points ansibleRequirementsFile here.
 collections:
-  - name: community.crypto
-    version: 2.26.2
-  - name: community.general
-    version: 10.6.0
+  - name: ansible.netcommon
+    version: 8.6.2
   - name: ansible.posix
-    version: 2.0.0
-  - name: kubernetes.core
-    version: 5.2.0
-  - name: community.docker
-    version: 4.6.0
-  - name: community.vmware
-    version: 5.6.0
+    version: 2.2.2
   - name: awx.awx
     version: 24.6.1
+  - name: community.crypto
+    version: 3.3.0
+  - name: community.docker
+    version: 5.2.2
+  - name: community.general
+    version: 13.3.0
   - name: community.hashi_vault
-    version: 6.2.0
-  - name: ansible.netcommon
-    version: 8.0.0
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-25.4.425.tar.gz/sthings-container-25.4.425.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-25.3.570.tar.gz/sthings-baseos-25.3.570.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-25.4.837.tar.gz/sthings-awx-25.4.837.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-25.1.568.tar.gz/sthings-rke-25.1.568.tar.gz
+    version: 7.1.0
+  - name: community.vmware
+    version: 6.2.1
+  - name: kubernetes.core
+    version: 6.5.0
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.812.1209/sthings-awx-26.812.1209.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.820.1251/sthings-container-26.820.1251.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.730.1176/sthings-rke-26.730.1176.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.821.1252/sthings-baseos-26.821.1252.tar.gz

--- a/tests/vm/requirements.yaml
+++ b/tests/vm/requirements.yaml
@@ -23,6 +23,6 @@ collections:
   - name: kubernetes.core
     version: 6.5.0
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.812.1209/sthings-awx-26.812.1209.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.820.1251/sthings-container-26.820.1251.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.821.1257/sthings-container-26.821.1257.tar.gz
   - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.730.1176/sthings-rke-26.730.1176.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.821.1252/sthings-baseos-26.821.1252.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.821.1259/sthings-baseos-26.821.1259.tar.gz

--- a/tests/vm/requirements.yaml
+++ b/tests/vm/requirements.yaml
@@ -1,24 +1,28 @@
 ---
+# Kept in sync with stuttgart-things/ansible requirements.yaml, which is the
+# canonical consumer-facing pin list. This copy is live config, not just a
+# fixture: configuration/vsphere-vm.go defaults to tests/vm/execution-vars.yaml
+# on main, and that file points ansibleRequirementsFile here.
 collections:
-  - name: community.crypto
-    version: 2.26.2
-  - name: community.general
-    version: 10.6.0
+  - name: ansible.netcommon
+    version: 8.6.2
   - name: ansible.posix
-    version: 2.0.0
-  - name: kubernetes.core
-    version: 5.2.0
-  - name: community.docker
-    version: 4.6.0
-  - name: community.vmware
-    version: 5.6.0
+    version: 2.2.2
   - name: awx.awx
     version: 24.6.1
+  - name: community.crypto
+    version: 3.3.0
+  - name: community.docker
+    version: 5.2.2
+  - name: community.general
+    version: 13.3.0
   - name: community.hashi_vault
-    version: 6.2.0
-  - name: ansible.netcommon
-    version: 8.0.0
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-25.4.425.tar.gz/sthings-container-25.4.425.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-25.3.570.tar.gz/sthings-baseos-25.3.570.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-25.4.837.tar.gz/sthings-awx-25.4.837.tar.gz
-  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-25.1.568.tar.gz/sthings-rke-25.1.568.tar.gz
+    version: 7.1.0
+  - name: community.vmware
+    version: 6.2.1
+  - name: kubernetes.core
+    version: 6.5.0
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.812.1209/sthings-awx-26.812.1209.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.820.1251/sthings-container-26.820.1251.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.730.1176/sthings-rke-26.730.1176.tar.gz
+  - name: https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.821.1252/sthings-baseos-26.821.1252.tar.gz


### PR DESCRIPTION
Zwei offene Punkte aus dem letzten Durchgang, ein Commit je Punkt.

## 1. `fix(vm)`: Collection-Pins waren Produktivkonfiguration, nicht Fixture

`tests/vm/requirements.yaml` sieht wie ein Testfixture aus, ist aber **live config**: `configuration/vsphere-vm.go:49` hat als Default

```
https://raw.githubusercontent.com/stuttgart-things/blueprints/refs/heads/main/tests/vm/execution-vars.yaml
```

und diese Datei zeigt mit `ansibleRequirementsFile` genau hierher. Wer den Default nutzt, bekam also seit rund einem Jahr veraltete Pins:

| Collection | vorher | jetzt |
|---|---|---|
| baseos | `25.3.570` | `26.821.1252` |
| container | `25.4.425` | `26.820.1251` |
| awx | `25.4.837` | `26.812.1209` |
| rke | `25.1.568` | `26.730.1176` |

Beide Kopien sind jetzt mit `stuttgart-things/ansible` → `requirements.yaml` synchron, der kanonischen consumer-facing Pin-Liste. `tests/vm/ansible/requirements.yaml` war eine identische veraltete Zweitkopie und wird aus `docs/modules/vm.md` referenziert, deshalb ebenfalls mitgezogen.

Beide Dateien haben jetzt einen Kopfkommentar, der festhält woher sie stammen — und dass die erste nicht wegwerfbar ist.

**Verifiziert:** installiert sauber mit `ansible-galaxy install -r` unter ansible 14.3.1 (core 2.21.3), also der Version die der vm-Container inzwischen fährt, ohne `requires_ansible`-Warnungen beim Wiederholungslauf.

## 2. `ci`: tote Asset-Globs

Jedes Release loggte:

```
✘ The asset dist/**/*.{go,mod,sum} cannot be read, and will be ignored.
```

`dist/` existiert hier nicht; `go.mod`/`go.sum` in den git-Assets ebenso wenig (jedes Modul hat seine eigenen), die matchten still ins Leere.

`docs/**/*.{pdf,md}` hat dagegen gematcht — aber es gibt **keine PDFs** in `docs/`, nur 10 Markdown-Quellen. Der Glob hat also Doku-Quelldateien an jedes GitHub-Release gehängt. Da Module hier per git-Ref konsumiert werden und die Doku über mkdocs läuft, fliegt der Assets-Block ganz raus statt umgebogen zu werden.

## Nicht Teil dieses PRs

Der dritte offene Punkt — ansible 10.4.0 im baseos-venv gegen Collections, die core ≥2.19 brauchen — liegt im ansible-Repo: stuttgart-things/ansible#1159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUHNVfwo2mTTupe8vFVjaW