### PR TITLE
feat(vm): plumb env secrets through to the ansible module

### DIFF
--- a/vm/ansible-export.go
+++ b/vm/ansible-export.go
@@ -40,6 +40,11 @@ func (m *Vm) ExecuteAnsibleWithExport(
 	sshUser *dagger.Secret,
 	// +optional
 	sshPassword *dagger.Secret,
+	// Extra environment for the Ansible container, as a secret in dotenv format
+	// (NAME=value per line). Needed by playbooks that resolve values with
+	// lookup('env', ...), which is evaluated on the controller, not the target.
+	// +optional
+	envSecrets *dagger.Secret,
 	// +optional
 	// +default="https://raw.githubusercontent.com/stuttgart-things/ansible/refs/heads/main/templates/requirements.yaml.tmpl"
 	requirementsTemplate string,
@@ -71,6 +76,7 @@ func (m *Vm) ExecuteAnsibleWithExport(
 			Requirements:   prep.requirements,
 			SSHUser:        sshUser,
 			SSHPassword:    sshPassword,
+			EnvSecrets:     envSecrets,
 		})
 
 	return exportDir, nil
@@ -106,6 +112,11 @@ func (m *Vm) ExecuteAnsibleEncryptAndCommit(
 	sshUser *dagger.Secret,
 	// +optional
 	sshPassword *dagger.Secret,
+	// Extra environment for the Ansible container, as a secret in dotenv format
+	// (NAME=value per line). Needed by playbooks that resolve values with
+	// lookup('env', ...), which is evaluated on the controller, not the target.
+	// +optional
+	envSecrets *dagger.Secret,
 	// +optional
 	// +default="https://raw.githubusercontent.com/stuttgart-things/ansible/refs/heads/main/templates/requirements.yaml.tmpl"
 	requirementsTemplate string,
@@ -159,7 +170,7 @@ func (m *Vm) ExecuteAnsibleEncryptAndCommit(
 	// PHASE 1: Execute Ansible and export files
 	exportDir, err := m.ExecuteAnsibleWithExport(
 		ctx, src, playbooks, exportPaths, requirements, inventory, hosts, parameters, parametersFile,
-		vaultAppRoleID, vaultSecretID, vaultURL, sshUser, sshPassword,
+		vaultAppRoleID, vaultSecretID, vaultURL, sshUser, sshPassword, envSecrets,
 		requirementsTemplate, requirementsData, inventoryType,
 	)
 	if err != nil {

--- a/vm/ansible.go
+++ b/vm/ansible.go
@@ -34,6 +34,12 @@ func (m *Vm) ExecuteAnsible(
 	sshUser *dagger.Secret,
 	// +optional
 	sshPassword *dagger.Secret,
+	// Extra environment for the Ansible container, as a secret in dotenv format
+	// (NAME=value per line). Needed by playbooks that resolve values with
+	// lookup('env', ...), which is evaluated on the controller, not the target --
+	// e.g. sthings.container.kind_machinery reads SOPS_AGE_KEY that way.
+	// +optional
+	envSecrets *dagger.Secret,
 	// +optional
 	// +default="https://raw.githubusercontent.com/stuttgart-things/ansible/refs/heads/main/templates/requirements.yaml.tmpl"
 	requirementsTemplate string,
@@ -65,6 +71,7 @@ func (m *Vm) ExecuteAnsible(
 			Requirements:   prep.requirements,
 			SSHUser:        sshUser,
 			SSHPassword:    sshPassword,
+			EnvSecrets:     envSecrets,
 		})
 }
 

--- a/vm/dagger.json
+++ b/vm/dagger.json
@@ -7,8 +7,8 @@
   "dependencies": [
     {
       "name": "ansible",
-      "source": "github.com/stuttgart-things/dagger/ansible@v0.123.0",
-      "pin": "f2cd87dc9ef63af1121c308bae2b68f60325a2d1"
+      "source": "github.com/stuttgart-things/dagger/ansible@v0.125.0",
+      "pin": "67ed9a56acd3894635f4376731b8bef6a3464c1f"
     },
     {
       "name": "configuration",

--- a/vm/local.go
+++ b/vm/local.go
@@ -44,6 +44,10 @@ func (m *Vm) BakeLocal(
 	ansibleUser *dagger.Secret,
 	// +optional
 	ansiblePassword *dagger.Secret,
+	// Extra environment for the Ansible container, as a secret in dotenv format
+	// (NAME=value per line), for playbooks using lookup('env', ...).
+	// +optional
+	envSecrets *dagger.Secret,
 	// +optional
 	ansibleParameters string,
 	// +optional
@@ -162,15 +166,15 @@ func (m *Vm) BakeLocal(
 				vaultRoleID,
 				vaultSecretID,
 				vaultToken,
-				nil, // sopsAgeKey
-				"",  // encryptedFiles
-				nil, // kubeConfig
-				"",  // kubeConfigPath
-				nil, // encryptedKubeConfig
-				"",  // kubeSecretName
-				"",  // kubeSecretNamespace
-				"",  // kubeSecretJsonpath
-				"",  // kubeSecretTfVar
+				nil,   // sopsAgeKey
+				"",    // encryptedFiles
+				nil,   // kubeConfig
+				"",    // kubeConfigPath
+				nil,   // encryptedKubeConfig
+				"",    // kubeSecretName
+				"",    // kubeSecretNamespace
+				"",    // kubeSecretJsonpath
+				"",    // kubeSecretTfVar
 				false, // exportTfOutput
 			)
 
@@ -260,6 +264,7 @@ func (m *Vm) BakeLocal(
 				vaultURL,
 				ansibleUser,
 				ansiblePassword,
+				envSecrets,
 				requirementsTemplate,
 				requirementsData,
 				inventoryType,
@@ -330,6 +335,7 @@ func (m *Vm) BakeLocal(
 				vaultURL,
 				ansibleUser,
 				ansiblePassword,
+				envSecrets,
 				requirementsTemplate,
 				requirementsData,
 				inventoryType,

--- a/vm/profile.go
+++ b/vm/profile.go
@@ -51,6 +51,10 @@ func (m *Vm) BakeLocalByProfile(
 	ansibleUser *dagger.Secret,
 	// +optional
 	ansiblePassword *dagger.Secret,
+	// Extra environment for the Ansible container, as a secret in dotenv format
+	// (NAME=value per line), for playbooks using lookup('env', ...).
+	// +optional
+	envSecrets *dagger.Secret,
 	// +optional
 	// +default="https://raw.githubusercontent.com/stuttgart-things/ansible/refs/heads/main/templates/requirements.yaml.tmpl"
 	requirementsTemplate string,
@@ -136,6 +140,7 @@ func (m *Vm) BakeLocalByProfile(
 		ansibleRequirementsFile,
 		ansibleUser,
 		ansiblePassword,
+		envSecrets,
 		ansibleParameters,
 		config.AnsibleInventoryType,
 		config.AnsibleWaitTimeout,


### PR DESCRIPTION
## Warum

Playbooks, die Werte per `lookup('env', 'NAME')` auflösen, lesen sie auf dem **Controller** — also im Container des ansible-Moduls — nicht auf dem Ziel. `sthings.container.kind_machinery` macht das für `SOPS_AGE_KEY` und `SOPS_GIT_TOKEN`, und über `vm` gab es bisher keinen Weg, die hineinzubekommen.

Das ansible-Modul hat dafür in [stuttgart-things/dagger v0.125.0](https://github.com/stuttgart-things/dagger/releases/tag/v0.125.0) `--env-secrets` bekommen: **ein** Secret im dotenv-Format, jeder Eintrag wird per `dag.SetSecret` einzeln neu verpackt, damit die Werte maskiert bleiben.

## Was hier passiert

Dependency `ansible` von `v0.123.0` auf `v0.125.0`, und derselbe Parameter an **allen** Funktionen, die Playbooks fahren:

| Funktion | |
|---|---|
| `execute-ansible` | ✅ |
| `execute-ansible-with-export` | ✅ |
| `execute-ansible-encrypt-and-commit` | ✅ |
| `bake-local` | ✅ |
| `bake-local-by-profile` | ✅ |

Die letzten beiden reichen ihn durch, statt intern `nil` zu übergeben — sonst wären ausgerechnet die Pipeline-Einstiegspunkte eine Sackgasse für Playbooks mit Controller-seitiger Environment.

## Benutzung

```bash
export ANSIBLE_ENV="SOPS_AGE_KEY=$SOPS_AGE_KEY
SOPS_GIT_TOKEN=$SOPS_GIT_TOKEN"

dagger call -m ./vm execute-ansible \
  --playbooks sthings.container.kind_machinery_profile \
  --hosts 10.31.101.107 \
  --env-secrets env:ANSIBLE_ENV \
  --ssh-user env:ANSIBLE_USER --ssh-password env:ANSIBLE_PASSWORD
```

`--hosts` erzeugt weiterhin das Inventory selbst; alternativ `--inventory <file>`.

## Verifiziert

- Durch das vm-Modul gegen ein Probe-Playbook: beide Variablen lösen im Container auf, mit korrekten Längen (53 bzw. 37 Zeichen), `ok=2 failed=0`.
- **Kein Leck:** das komplette Run-Log nach beiden Klartextwerten durchsucht → 0 Treffer.
- `task test-vm` läuft weiterhin komplett durch (Terraform-Lifecycle), `dagger run go test ./...` grün.
- Schema löst auf, keine Flag-Kollisionen; `gofmt` und `go vet` sauber. Der einzige `golangci-lint`-Fund liegt in `git.go:40` und ist vorbestehend.

Nebenbei formatiert gofmt einen bereits vorher unformatierten Kommentarblock in `local.go` mit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUHNVfwo2mTTupe8vFVjaW