### PR TITLE
fix(vm): decrypted secrets no longer land in the build log

### DIFF
--- a/vm/local.go
+++ b/vm/local.go
@@ -118,10 +118,13 @@ func (m *Vm) BakeLocal(
 		if err != nil {
 			return nil, fmt.Errorf("decrypting sops file failed: %w", err)
 		}
-		ctr = ctr.
-			WithNewFile(
-				fmt.Sprintf("%s/terraform.tfvars.json", workDir),
-				decryptedContent)
+		// Mounted-and-copied rather than WithNewFile: the plaintext must not
+		// become an operation argument, or it lands in the build log.
+		ctr = withSecretFile(
+			ctr,
+			fmt.Sprintf("%s/terraform.tfvars.json", workDir),
+			decryptedContent,
+			"tfvars-json")
 
 		// Extract Ansible SSH creds from SOPS-decrypted content (CLI flags take precedence)
 		if ansibleUser == nil || ansiblePassword == nil { // pragma: allowlist secret

--- a/vm/secretfile.go
+++ b/vm/secretfile.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"path"
+
+	"dagger/vm/internal/dagger"
+)
+
+// secretMountDir is outside any working directory so a mounted secret can never
+// shadow a real file or be picked up by Container.Directory().
+const secretMountDir = "/run/dagger-secrets"
+
+// withSecretFile writes content to dstPath inside ctr without ever passing the
+// plaintext as an operation argument.
+//
+// WithNewFile takes its contents as a plain Go string, and dagger records that
+// argument in the operation graph — so the value shows up verbatim in build
+// logs and in Dagger Cloud traces. Mounting the value as a secret and copying
+// it into place keeps the plaintext out of every argument: the exec only ever
+// sees paths.
+//
+// The copy is a real filesystem write, not a mount, so the file is part of the
+// resulting snapshot and Container.Directory() picks it up — which a mounted
+// secret on its own would not do.
+//
+// The digest in the command is a cache key, not decoration. Whether a mounted
+// secret participates in the exec cache key is a dagger implementation detail;
+// without something content-derived in the arguments, an unchanged command over
+// an unchanged parent filesystem could be served from cache and quietly keep a
+// stale file after the underlying secret was rotated. Hashing the whole
+// decrypted blob rather than any single field keeps the digest high-entropy, so
+// it is not a practical route back to the plaintext.
+func withSecretFile(ctr *dagger.Container, dstPath, content, secretName string) *dagger.Container {
+	mountPath := path.Join(secretMountDir, secretName)
+	digest := sha256.Sum256([]byte(content))
+
+	return ctr.
+		WithMountedSecret(mountPath, dag.SetSecret(secretName, content)).
+		WithExec([]string{"sh", "-c", fmt.Sprintf(
+			"cp %q %q  # content:%x", mountPath, dstPath, digest[:8])}).
+		WithoutMount(mountPath)
+}
+
+// directoryWithSecretFile is withSecretFile for callers that hold a Directory
+// rather than a Container: it round-trips through a throwaway container so the
+// plaintext still never becomes an operation argument.
+func (m *Vm) directoryWithSecretFile(
+	ctx context.Context,
+	dir *dagger.Directory,
+	dstPath, content, secretName string,
+) (*dagger.Directory, error) {
+	ctr, err := m.container(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("container init failed: %w", err)
+	}
+
+	const workDir = "/secret-write"
+
+	return withSecretFile(
+		ctr.WithDirectory(workDir, dir),
+		path.Join(workDir, dstPath),
+		content,
+		secretName,
+	).Directory(workDir), nil
+}

--- a/vm/terraform.go
+++ b/vm/terraform.go
@@ -120,14 +120,22 @@ func (m *Vm) ExecuteTerraform(
 						if err != nil {
 							return nil, fmt.Errorf("failed to marshal remaining vars from %s: %w", filePath, err)
 						}
-						tfDir = tfDir.WithNewFile(outputName, string(remainingJSON))
+						tfDir, err = m.directoryWithSecretFile(
+							ctx, tfDir, outputName, string(remainingJSON), "tfvars-remaining")
+						if err != nil {
+							return nil, fmt.Errorf("writing decrypted vars from %s: %w", filePath, err)
+						}
 					}
 					continue
 				}
 			}
 
 			outputName := strings.Replace(filePath, ".sops", "", 1)
-			tfDir = tfDir.WithNewFile(outputName, decryptedContent)
+			tfDir, err = m.directoryWithSecretFile(
+				ctx, tfDir, outputName, decryptedContent, "tfvars-decrypted")
+			if err != nil {
+				return nil, fmt.Errorf("writing decrypted %s: %w", filePath, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## The leak

`WithNewFile` takes its contents as a plain Go string, and dagger records that argument in the operation graph. Every SOPS blob we decrypted was printed verbatim into the build log and the Dagger Cloud trace:

```
withNewFile /src/terraform.tfvars.json (contents: "{
  "vsphere_server": "10.100.135.50",
  "vsphere_user": "patrick.hermann@lab.sva.de",
  "vsphere_password": "***2025!labD@4",
  "vm_ssh_user": "***", "vm_ssh_password": "***" }")
```

Only fragments matching an already-registered secret were masked — which is exactly why that password is *half* visible: the ssh password shares a prefix with it, so the scrubber ate the front and left the tail. `vsphere_user` was not masked at all. Observed on a real run in `stuttgart-things` (`pr-vm-deploy.yaml`).

## The fix

The value is mounted as a secret and copied into place, so the exec only ever sees paths — the plaintext is never an operation argument.

The copy is a **real filesystem write rather than a mount**, because the file has to survive into `Container.Directory()`; that directory is what gets handed to `Terraform.Execute`. A mounted secret alone does not appear in a directory snapshot, and terraform would silently lose its variables.

### The digest is a cache key, not decoration

Whether a mounted secret participates in the exec cache key is a dagger implementation detail. Without something content-derived in the arguments, an unchanged command over an unchanged parent filesystem could be served from cache and quietly keep a **stale file after the secret was rotated** — the failure mode being a password change that appears to apply but doesn't. The digest is taken over the whole blob rather than any single field, so it stays high-entropy and is not a practical route back to the plaintext.

## Sites

| file | what |
|---|---|
| `local.go` | the tfvars write in `BakeLocal` — the one observed in the wild |
| `terraform.go` | both decrypted writes in `ExecuteTerraform` |

## Checked and deliberately left alone

The remaining `WithNewFile` calls write either already-encrypted content (`ansible-export.go`, `local.go` export path) or non-secret data (`outputs.json` = VM IPs). The ansible inventory carries only hostnames and `ansible_ssh_common_args`; the ssh credentials reach ansible as secrets, not through the inventory.

## Verified

- `go build`, `go vet` clean
- `dagger functions` loads the module, all 12 functions unchanged (the helper is unexported, so no API surface change)
- No signature changes — callers pinned to this module need no edit beyond the version bump

## Not yet exercised end-to-end

The `local.go` path will be covered by the next `pr-vm-deploy` run in stuttgart-things once the pin moves off `v2.6.0`. The `ExecuteTerraform` sites are the same defect but are not reached by that workflow (it passes `sopsAgeKey: nil` there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4Jmc5323ePZTDZ7XR19a