### PR TITLE
fix(configuration): let CreateAnsibleRequirementFiles bust its render cache

### DIFF
--- a/configuration/ansible.go
+++ b/configuration/ansible.go
@@ -2,8 +2,14 @@ package main
 
 import (
 	"context"
+
 	"dagger/configuration/internal/dagger"
 )
+
+// cacheBusterMarker is the file whose contents vary to defeat memoisation.
+// Dot-prefixed and named for what it is, so it is obvious in a directory
+// listing that it carries no meaning of its own.
+const cacheBusterMarker = ".dagger-cache-buster"
 
 func (m *Configuration) CreateAnsibleRequirementFiles(
 	ctx context.Context,
@@ -19,7 +25,44 @@ func (m *Configuration) CreateAnsibleRequirementFiles(
 	// +optional
 	// +default=false
 	strictMode bool,
+	// Any value that changes between runs -- a timestamp, a CI run id. Forces a
+	// fresh render instead of a cached one.
+	//
+	// This is NOT the usual "+optional and then discarded" cache buster. Dagger
+	// memoises RenderFromFile on its arguments, and when template and data are
+	// remote those arguments are two URL STRINGS that never change; nothing can
+	// tell Dagger the content behind the URL moved. Discarding the value here
+	// would bust only THIS function and leave the inner call answering from its
+	// own cache.
+	//
+	// So the value is written into a marker file inside `src`, which IS an
+	// argument of the inner call. A different value means a different directory
+	// digest means a genuine re-render. The file is never read: with remote
+	// template and data RenderFromFile does not touch src at all, and with local
+	// ones it addresses templates by explicit path, so a dot-file alongside them
+	// is inert.
+	//
+	// The obvious approach -- appending ?cacheBuster= to the URLs -- does not
+	// work: RenderFromFile derives the data format from the string's suffix and
+	// rejects `.yaml?cacheBuster=...` as an unsupported format.
+	//
+	// RESIDUAL: this defeats Dagger's cache, not GitHub's. raw.githubusercontent
+	// serves a pushed change for a few minutes before it propagates, so a render
+	// seconds after a merge can still be stale. That window is bounded and
+	// self-healing; the Dagger one was neither.
+	//
+	// Left empty nothing is added and the behaviour is exactly as before.
+	// +optional
+	// +default=""
+	cacheBuster string,
 ) (*dagger.Directory, error) {
+
+	if cacheBuster != "" {
+		if src == nil {
+			src = dag.Directory()
+		}
+		src = src.WithNewFile(cacheBusterMarker, cacheBuster)
+	}
 
 	// RENDER TEMPLATES WITH DATA FROM FILE
 	renderedRequirementsFile := dag.Templating().RenderFromFile(

--- a/configuration/vsphere-vm.go
+++ b/configuration/vsphere-vm.go
@@ -42,6 +42,16 @@ func (m *Configuration) VsphereVm(
 	// +optional
 	// +default="https://raw.githubusercontent.com/stuttgart-things/ansible/refs/heads/main/templates/requirements-data.yaml"
 	ansibleRequirementsData string,
+	// Any value that changes between runs. Forces a fresh fetch of the remote
+	// ansible requirements instead of a cached render.
+	//
+	// It matters more here than in a throwaway execution: the rendered file is
+	// COMMITTED to the generated branch, so a stale render does not just affect
+	// one run -- it lands in the repository and every consumer of that branch
+	// inherits it.
+	// +optional
+	// +default=""
+	ansibleRequirementsCacheBuster string,
 	// +optional
 	// +default="true"
 	renderExecutionfile bool,
@@ -158,6 +168,7 @@ func (m *Configuration) VsphereVm(
 			ansibleRequirementsTemplate,
 			ansibleRequirementsData,
 			true,
+			ansibleRequirementsCacheBuster,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create ansible requirements: %w", err)

--- a/vm/ansible-export.go
+++ b/vm/ansible-export.go
@@ -55,9 +55,16 @@ func (m *Vm) ExecuteAnsibleWithExport(
 	// +optional
 	// +default="simple"
 	inventoryType string,
+	// Any value that changes between runs -- a timestamp, a CI run id. Threaded
+	// into CreateAnsibleRequirementFiles, where it forces a fresh fetch of the
+	// remote requirements instead of a cached render. Leave empty to keep the
+	// previous behaviour.
+	// +optional
+	// +default=""
+	cacheBuster string,
 ) (*dagger.Directory, error) {
 
-	prep, err := m.prepareAnsibleExecution(ctx, src, requirements, inventory, hosts, parameters, parametersFile, requirementsTemplate, requirementsData, inventoryType)
+	prep, err := m.prepareAnsibleExecution(ctx, src, requirements, inventory, hosts, parameters, parametersFile, requirementsTemplate, requirementsData, inventoryType, cacheBuster)
 	if err != nil {
 		return nil, err
 	}
@@ -127,6 +134,13 @@ func (m *Vm) ExecuteAnsibleEncryptAndCommit(
 	// +optional
 	// +default="simple"
 	inventoryType string,
+	// Any value that changes between runs -- a timestamp, a CI run id. Threaded
+	// into CreateAnsibleRequirementFiles, where it forces a fresh fetch of the
+	// remote requirements instead of a cached render. Leave empty to keep the
+	// previous behaviour.
+	// +optional
+	// +default=""
+	cacheBuster string,
 	// AGE public key for SOPS encryption
 	agePublicKey *dagger.Secret,
 	// File extension for SOPS encryption (e.g., "yaml", "json")
@@ -171,7 +185,7 @@ func (m *Vm) ExecuteAnsibleEncryptAndCommit(
 	exportDir, err := m.ExecuteAnsibleWithExport(
 		ctx, src, playbooks, exportPaths, requirements, inventory, hosts, parameters, parametersFile,
 		vaultAppRoleID, vaultSecretID, vaultURL, sshUser, sshPassword, envSecrets,
-		requirementsTemplate, requirementsData, inventoryType,
+		requirementsTemplate, requirementsData, inventoryType, cacheBuster,
 	)
 	if err != nil {
 		return "", fmt.Errorf("ansible execution failed: %w", err)

--- a/vm/ansible.go
+++ b/vm/ansible.go
@@ -50,9 +50,16 @@ func (m *Vm) ExecuteAnsible(
 	// +optional
 	// +default="simple"
 	inventoryType string,
+	// Any value that changes between runs -- a timestamp, a CI run id. Threaded
+	// into CreateAnsibleRequirementFiles, where it forces a fresh fetch of the
+	// remote requirements instead of a cached render. Leave empty to keep the
+	// previous behaviour.
+	// +optional
+	// +default=""
+	cacheBuster string,
 ) (bool, error) {
 
-	prep, err := m.prepareAnsibleExecution(ctx, src, requirements, inventory, hosts, parameters, parametersFile, requirementsTemplate, requirementsData, inventoryType)
+	prep, err := m.prepareAnsibleExecution(ctx, src, requirements, inventory, hosts, parameters, parametersFile, requirementsTemplate, requirementsData, inventoryType, cacheBuster)
 	if err != nil {
 		return false, err
 	}
@@ -96,6 +103,7 @@ func (m *Vm) prepareAnsibleExecution(
 	requirementsTemplate string,
 	requirementsData string,
 	inventoryType string,
+	cacheBuster string,
 ) (*ansiblePrepResult, error) {
 
 	if src == nil {
@@ -132,6 +140,7 @@ func (m *Vm) prepareAnsibleExecution(
 				TemplatePaths: requirementsTemplate,
 				DataFile:      requirementsData,
 				StrictMode:    false,
+				CacheBuster:   cacheBuster,
 			},
 		)
 		requirements = generatedRequirements.File("requirements.yaml")

--- a/vm/local.go
+++ b/vm/local.go
@@ -62,6 +62,17 @@ func (m *Vm) BakeLocal(
 	// +optional
 	// +default="https://raw.githubusercontent.com/stuttgart-things/ansible/refs/heads/main/templates/requirements-data.yaml"
 	requirementsData string,
+	// Any value that changes between runs -- a timestamp, a CI run id. Threaded
+	// down to CreateAnsibleRequirementFiles, where it forces a fresh fetch of the
+	// remote requirements instead of a cached render. Leave empty to keep the
+	// previous behaviour.
+	//
+	// Worth passing from CI: the dagger-labda runner keeps its engine between
+	// runs, so without it a merged collection bump can stay invisible to the
+	// pipeline indefinitely.
+	// +optional
+	// +default=""
+	cacheBuster string,
 	// +optional
 	// +default=3
 	terraformMaxRetries int,
@@ -271,6 +282,7 @@ func (m *Vm) BakeLocal(
 				requirementsTemplate,
 				requirementsData,
 				inventoryType,
+				cacheBuster,
 			)
 		if err != nil {
 			return nil, fmt.Errorf("ansible execution with export failed: %w", err)
@@ -342,6 +354,7 @@ func (m *Vm) BakeLocal(
 				requirementsTemplate,
 				requirementsData,
 				inventoryType,
+				cacheBuster,
 			)
 
 		if err != nil {

--- a/vm/profile.go
+++ b/vm/profile.go
@@ -61,6 +61,16 @@ func (m *Vm) BakeLocalByProfile(
 	// +optional
 	// +default="https://raw.githubusercontent.com/stuttgart-things/ansible/refs/heads/main/templates/requirements-data.yaml"
 	requirementsData string,
+	// Any value that changes between runs -- a timestamp, a CI run id. Threaded
+	// down to CreateAnsibleRequirementFiles, where it forces a fresh fetch of the
+	// remote requirements instead of a cached render.
+	//
+	// Deliberately NOT a field in execution.yaml: it is a property of THIS run,
+	// not of the VM being built, and committing one would make it stale by
+	// definition. pr-vm-deploy.yaml should pass the run id.
+	// +optional
+	// +default=""
+	cacheBuster string,
 	// Inventory type: "simple" (default [all] group) or "cluster" (master/worker groups)
 	// +optional
 	// +default="simple"
@@ -146,6 +156,7 @@ func (m *Vm) BakeLocalByProfile(
 		config.AnsibleWaitTimeout,
 		requirementsTemplate,
 		requirementsData,
+		cacheBuster,
 		maxRetries,
 		retryDelay,
 		inventoryType,


### PR DESCRIPTION
A merged pin in the ansible repo's `templates/requirements-data.yaml` never reached a pipeline run.

Dagger memoises `Templating.RenderFromFile` on its arguments. When template and data are remote, those arguments are two **URL strings** that never change — nothing can tell Dagger the content behind the URL moved.

## Witnessed

`sthings-baseos-26.824.1274` was released and pinned on `main`, `curl` on the raw URL returned the new pin, and the Dagger run still installed the pre-fix collection:

```
The role 'install-configure-powerdns' was not found
```

Calling the configuration module *directly* rendered the NEW pin correctly — a different call graph is a cache miss. That makes this easy to misdiagnose as "the render is fine, must be something else".

**This bites CI harder than laptops:** `dagger-labda` is a self-hosted runner with a persistent engine, so `pr-vm-deploy.yaml` shares the stale cache across runs. A collection bump is not live for the pipeline until something busts it.

## The fix

New optional `cacheBuster`, threaded from `BakeLocalByProfile` / `BakeLocal` / `ExecuteAnsible` / `ExecuteAnsibleWithExport` and from `VsphereVm`. Empty keeps the previous behaviour exactly.

It is deliberately **not** the usual `+optional`-and-then-discarded buster (as in `CreateVaultKubernetesAuth`): that would bust only the outer function and leave `RenderFromFile` answering from its own cache. The value is written into a marker file inside `src`, which *is* an argument of the inner call — a different value is a different directory digest and a genuine re-render. The file is never read.

`?cacheBuster=` appended to the URLs was tried first and does not work: `RenderFromFile` derives the data format from the string's suffix and rejects `.yaml?cacheBuster=...` as an unsupported format. Fixing that would mean a release of `stuttgart-things/dagger/templating` (pinned at v0.112.0); the marker file needs no third repo.

`VsphereVm` gets it too, where it matters more: there the rendered requirements are **committed** to the generated branch, so a stale render lands in the repository rather than affecting one run.

## Residual

This defeats Dagger's cache, not GitHub's. `raw.githubusercontent` serves a pushed change for a few minutes before it propagates, so a render seconds after a merge can still be stale. That window is bounded and self-healing; the Dagger one was neither.

## Verification

Same command twice, differing only in the flag:

| | Result |
|---|---|
| without `--cache-buster` | `The role 'install-configure-powerdns' was not found` |
| with `--cache-buster` | role resolves, all four tasks load, stops at the Vault lookup (no creds) |

## Follow-up

`pr-vm-deploy.yaml` should pass `--cache-buster ${{ github.run_id }}-${{ github.run_attempt }}` to its two `bake-local-by-profile` calls once this is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYkrt9hhBe7ei2d6v3Wudv
