### PR TITLE
fix(argocd): stop CreateVaultKubernetesAuth creating an unused namespace

### DIFF
--- a/argocd/create_vault_k8s_auth.go
+++ b/argocd/create_vault_k8s_auth.go
@@ -247,6 +247,7 @@ func (m *Argocd) CreateVaultKubernetesAuth(
 		"name":              authName,
 		"reviewerName":      reviewerName,
 		"reviewerNamespace": reviewerNamespace,
+		"namespaceDocs":     namespaceDocs(reviewerNamespace, boundNamespaces),
 	})
 	if err != nil {
 		return "", fmt.Errorf("marshal manifest vars: %w", err)
@@ -483,6 +484,32 @@ echo "vault k8s auth %s/%s ready (reviewer: %s/%s, bound: %s, policies: %s)"`,
 	return strings.TrimSpace(out), nil
 }
 
+// namespaceDocs renders one Namespace document per namespace this call actually
+// puts something into: the reviewer's, and the bound ServiceAccounts'.
+//
+// It used to render `--namespace` instead, which is wrong as soon as the
+// reviewer and the bound account are moved elsewhere: --namespace then names
+// nothing this call touches, yet the Namespace was created anyway. Measured on
+// test-infra1 2026-08-24 -- a cert-manager-only run left behind an empty
+// `external-secrets` namespace, purely because that is the ESO default.
+//
+// In the single-account (ESO) shape reviewer and bound namespace are both
+// --namespace, so this renders exactly the one document it always did.
+func namespaceDocs(reviewerNamespace string, boundNamespaces []string) string {
+	seen := map[string]bool{}
+	var b strings.Builder
+
+	for _, ns := range append([]string{reviewerNamespace}, boundNamespaces...) {
+		if ns == "" || seen[ns] {
+			continue
+		}
+		seen[ns] = true
+		b.WriteString("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: " + ns + "\n---\n")
+	}
+
+	return b.String()
+}
+
 // splitCSV turns a comma-separated argument into a trimmed, empty-free slice.
 // Dagger has no []string argument type reachable from the CLI, so every list
 // crosses the boundary as one string.
@@ -511,19 +538,7 @@ func splitCSV(in string) []string {
 //
 // The reviewer namespace is created only when it differs from .namespace, so
 // the default single-account case renders exactly the documents it always did.
-const vaultK8sAuthManifestTemplate = `apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .namespace }}
-{{- if ne .reviewerNamespace .namespace }}
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .reviewerNamespace }}
-{{- end }}
----
-apiVersion: v1
+const vaultK8sAuthManifestTemplate = `{{ .namespaceDocs }}apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .reviewerName }}


### PR DESCRIPTION
Found by running the real thing, not by reading it.

The manifest rendered `Namespace/{{ .namespace }}` unconditionally. That is wrong the moment reviewer and bound ServiceAccount are moved elsewhere: `--namespace` then names nothing the call touches, yet the Namespace is created anyway.

## Measured

A cert-manager-only run on `test-infra1` (`--reviewer-namespace kube-system`, `--bound-service-account-namespaces cert-manager`) left behind an **empty `external-secrets` namespace**, purely because that is the ESO default for `--namespace`:

```
namespace/external-secrets serverside-applied     <- nothing asked for this
namespace/kube-system serverside-applied
serviceaccount/vault-auth-reviewer-dagger serverside-applied
```

## Fix

Namespaces are derived from what the call actually puts something into: the reviewer's, plus the bound ServiceAccounts', deduplicated.

In the single-account (ESO) shape both are `--namespace`, so exactly the one document it always rendered comes out — **no behaviour change for existing callers**.

## Verification

Table test over four cases — ESO default, reviewer split off, duplicates collapse, empty entries skipped:

```
=== RUN   TestNamespaceDocs
--- PASS: TestNamespaceDocs (0.00s)
```

Run under `dagger run -- go test`: the generated dagger package panics at `init()` without a session, so a bare `go test` cannot exercise this package at all. Worth knowing before anyone else tries.

The template render was separately checked for the ESO case and is unchanged.

## Context

The rest of the run this was found in worked: the Dagger-provisioned mount issued a real certificate on `test-infra1`, signed by the LabDA Vault PKI —

```
CN     = dagger-probe.test-infra1.4sthings.tiab.ssc.sva.de
issuer = O=SVA, OU=Stuttgart-Things, CN=tiab.labda.sva.de
```

so this is a stray side effect, not a broken path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYkrt9hhBe7ei2d6v3Wudv
