### PR TITLE
fix(flux): render-infra dropped all but the first substitute variable

### DIFF
--- a/flux/examples/infra-values-test-infra1.yaml
+++ b/flux/examples/infra-values-test-infra1.yaml
@@ -1,0 +1,84 @@
+---
+# test-infra1 (LabDA) -- a full eight-component set, kept as the worked
+# example next to the minimal infra-values.yaml.
+#
+# It describes what that cluster actually runs, which is what made it useful:
+# rendering this and comparing against the live Kustomizations is how the
+# substitute bug and the stale cert-manager pin were both found. Every path
+# matches the running cluster, and the substitute maps match wherever this file
+# spells a value out.
+source:
+  enabled: true
+  name: flux-infra
+  url: https://github.com/stuttgart-things/flux.git
+  tag: v1.27.0
+  interval: 1m0s
+
+components:
+  cilium-lb:
+    enabled: true
+    templateName: infrastructure
+    params:
+      path: ./infra/cilium/components/lb
+      sourceRefName: flux-infra
+      substitute: CILIUM_LB_IP_START=10.100.136.224,CILIUM_LB_IP_STOP=10.100.136.224
+
+  cilium-gateway:
+    enabled: true
+    templateName: infrastructure
+    params:
+      path: ./infra/cilium/components/gateway
+      sourceRefName: flux-infra
+      substitute: CILIUM_GATEWAY_NAME=cilium-gateway,CILIUM_GATEWAY_NAMESPACE=default,CILIUM_GATEWAY_DOMAIN=test-infra1.4sthings.tiab.ssc.sva.de,CILIUM_GATEWAY_TLS_SECRET=wildcard-test-infra1-tls
+
+  cert-manager-install:
+    enabled: true
+    templateName: cert-manager
+    params:
+      path: ./infra/cert-manager/components/install
+      sourceRefName: flux-infra
+      # MUSS gesetzt werden. Das KCL-Modul (claim-flux-kustomizations:0.3.33)
+      # traegt v1.19.1 als eigenen Default und schreibt ihn als expliziten
+      # substitute -- der schlaegt den Base-Default v1.21.1. Ohne diese Zeile
+      # dreht ein Apply cert-manager zwei Minor-Versionen zurueck.
+      certManagerVersion: v1.21.1
+
+  cert-manager-selfsigned:
+    enabled: true
+    templateName: infrastructure
+    params:
+      path: ./infra/cert-manager/components/selfsigned
+      sourceRefName: flux-infra
+      substitute: CERT_MANAGER_NAMESPACE=cert-manager,CERT_MANAGER_CA_NAME=cluster-ca,CERT_MANAGER_CA_SECRET=cluster-ca-secret,CERT_MANAGER_SELFSIGNED_DOMAIN=test-infra1.4sthings.tiab.ssc.sva.de,CERT_MANAGER_SELFSIGNED_CERT_NAME=wildcard-test-infra1-tls,CERT_MANAGER_SELFSIGNED_SECRET_NAME=wildcard-test-infra1-tls,CERT_MANAGER_SELFSIGNED_CERT_NAMESPACE=default,CERT_MANAGER_SELFSIGNED_ISSUER=vault-pki-4sthings
+
+  trust-manager:
+    enabled: true
+    templateName: infrastructure
+    params:
+      path: ./infra/trust-manager
+      sourceRefName: flux-infra
+      substitute: TRUST_MANAGER_NAMESPACE=cert-manager,TRUST_BUNDLE_VAULT_CA_SECRET=vault-pki-ca,TRUST_BUNDLE_VAULT_CA_KEY=ca.crt
+
+  openebs:
+    enabled: true
+    templateName: openebs
+    params:
+      path: ./infra/openebs
+      sourceRefName: flux-infra
+      openebsVersion: '4.5.1'
+
+  flux-web:
+    enabled: true
+    templateName: infrastructure
+    params:
+      path: ./apps/flux-web
+      sourceRefName: flux-infra
+      substitute: FLUX_WEB_NAMESPACE=flux-system,FLUX_WEB_VERSION=0.58.1,GATEWAY_NAME=cilium-gateway,GATEWAY_NAMESPACE=default,HOSTNAME=flux,DOMAIN=test-infra1.4sthings.tiab.ssc.sva.de
+
+  headlamp:
+    enabled: true
+    templateName: infrastructure
+    params:
+      path: ./apps/headlamp
+      sourceRefName: flux-infra
+      substitute: HEADLAMP_NAMESPACE=headlamp,HEADLAMP_VERSION=0.44.0,GATEWAY_NAME=cilium-gateway,GATEWAY_NAMESPACE=default,HOSTNAME=headlamp,DOMAIN=test-infra1.4sthings.tiab.ssc.sva.de

--- a/flux/infra.go
+++ b/flux/infra.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -322,18 +323,29 @@ func renderKustomization(
 	}
 	sort.Strings(keys)
 
-	pairs := make([]string, 0, len(keys))
+	// Parameters travel as a FILE, not as the comma-separated --parameters
+	// string. That string cannot carry `substitute` at all: its value is itself
+	// a comma-separated list, so joining it with the other parameters destroys
+	// the boundary before the KCL module ever sees it, and the module's own
+	// split then keeps only the first pair.
+	//
+	// It failed silently, which is the worst part -- the render succeeded and
+	// produced a valid-looking Kustomization. Measured on test-infra1
+	// 2026-08-24: eight substitute variables went in, `CERT_MANAGER_NAMESPACE`
+	// came out, and the wildcard certificate would have been issued for the
+	// sentinel `set-INFRA_DOMAIN.invalid`.
+	//
+	// A YAML document has no such ambiguity, and `--parameters-file` is the
+	// channel the KCL module offers for exactly this.
+	var b strings.Builder
+	b.WriteString("---\n")
 	for _, k := range keys {
-		v := params[k]
-		// The KCL module takes parameters as one comma-separated string, so a
-		// value containing a comma would silently split into two parameters.
-		// The substitute parameter is the documented exception -- it is itself
-		// a comma-separated list and the module parses it that way.
-		if strings.Contains(v, ",") && k != "substitute" {
-			return "", fmt.Errorf("parameter %q contains a comma, which the KCL parameter string cannot express: %q", k, v)
-		}
-		pairs = append(pairs, k+"="+v)
+		b.WriteString(k + ": " + strconv.Quote(params[k]) + "\n")
 	}
+
+	paramsFile := dag.Directory().
+		WithNewFile("parameters.yaml", b.String()).
+		File("parameters.yaml")
 
 	// FormatOutput is left at its default. It used to corrupt this module's
 	// output -- the post-processor assumed an `items:` list and its guard only
@@ -344,9 +356,9 @@ func renderKustomization(
 	// anyway: the generated client drops optional arguments that equal the
 	// zero value, so `FormatOutput: false` is never transmitted.
 	return dag.Kcl().Run(dagger.KclRunOpts{
-		OciSource:  ociSource,
-		Parameters: strings.Join(pairs, ","),
-		Entrypoint: entrypoint,
+		OciSource:      ociSource,
+		ParametersFile: paramsFile,
+		Entrypoint:     entrypoint,
 	}).Contents(ctx)
 }
 


### PR DESCRIPTION
Found by running `render-infra` against `test-infra1`'s own eight components and diffing the result against the live cluster — which is what the function is meant for, so it seemed fair to try it that way first.

## The bug

`renderKustomization` joined every parameter into one comma-separated `--parameters` string. **`substitute` cannot survive that**: its value is itself a comma-separated list, so the join destroyed the boundary before the KCL module saw it, and the module's own split then kept only the first pair.

The code exempted `substitute` from its own comma check with the comment *"the module parses it that way"* — but by then there was nothing left to parse correctly.

**It failed silently.** The render succeeded and produced valid-looking Kustomizations:

| component | in | out |
|---|---|---|
| `cilium-lb` | 2 | 1 — no `CILIUM_LB_IP_STOP` |
| `cilium-gateway` | 4 | 1 — no domain, no TLS secret |
| `cert-manager-selfsigned` | 8 | 1 |
| `trust-manager` | 3 | 1 |
| `flux-web` / `headlamp` | 6 each | 1 each |

Applied, the wildcard certificate would have been issued for the sentinel `set-INFRA_DOMAIN.invalid` and the Gateway would have had no TLS secret.

## The fix

Parameters travel as a YAML file via `--parameters-file`, the channel the KCL module offers for exactly this. A YAML document has no such ambiguity.

After the fix all eight components carry exactly the variables the values file names, and the rendered `path` and `substitute` maps match the live cluster wherever the values file spells a value out.

## Second finding, not fixed here

**The KCL module pins cert-manager to `v1.19.1`** and writes it as an *explicit* substitute, which beats the base default of `v1.21.1`. The cluster runs v1.21.1.

```
live kustomization : v1.21.1
render (KCL 0.3.33): v1.19.1
actually running   : v1.21.1
base default       : v1.21.1
```

Applying the rendered output would have **downgraded cert-manager by two minor versions**, silently. The new example carries `certManagerVersion` explicitly with a comment saying why, but the module pin in `claim-flux-kustomizations` is worth bumping separately.

Worth knowing given what else turned up today: cert-manager v1.21 is the release that stopped shipping the `serviceaccounts/token` RBAC, so a silent downgrade across that line changes more than a version string.

## Also added

`examples/infra-values-test-infra1.yaml` — a full eight-component set describing a real cluster, next to the minimal example. It is what made the comparison possible.

Part of stuttgart-things#2569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYkrt9hhBe7ei2d6v3Wudv
