### PR TITLE
fix(flux): tell "cannot reach cluster" apart from "not ready yet"

### DIFF
--- a/flux/infra.go
+++ b/flux/infra.go
@@ -70,7 +70,7 @@ func (m *Flux) RenderInfra(
 	valuesFile *dagger.File,
 	// OCI KCL module rendering the Kustomizations
 	// +optional
-	// +default="ghcr.io/stuttgart-things/claim-flux-kustomizations:0.3.33"
+	// +default="ghcr.io/stuttgart-things/claim-flux-kustomizations:0.3.34"
 	ociSource string,
 	// KCL entrypoint file name
 	// +optional
@@ -111,7 +111,7 @@ func (m *Flux) BootstrapInfra(
 	valuesFile *dagger.File,
 	// OCI KCL module rendering the Kustomizations
 	// +optional
-	// +default="ghcr.io/stuttgart-things/claim-flux-kustomizations:0.3.33"
+	// +default="ghcr.io/stuttgart-things/claim-flux-kustomizations:0.3.34"
 	ociSource string,
 	// KCL entrypoint file name
 	// +optional
@@ -384,6 +384,24 @@ func waitForKustomizations(
 ) ([]string, error) {
 	if len(names) == 0 {
 		return nil, nil
+	}
+
+	// Preflight. Without it an unusable kubeconfig is indistinguishable from
+	// "nothing is ready yet": every per-name call fails, each failure is counted
+	// as not-ready, and after the timeout the function blames all the
+	// components. That happened on 2026-08-24 with a kubeconfig path that
+	// simply did not exist -- the report named eight healthy Kustomizations as
+	// pending, and the real message ("failed to read secret file ... no such
+	// file or directory") was never surfaced.
+	//
+	// One unfiltered list call separates the two: if the cluster cannot be
+	// reached at all, say so instead of waiting out the clock and then lying
+	// about which components are at fault.
+	if _, err := fluxCliContainer(fluxCliImage, kubeConfig).
+		WithEnvVariable("CACHEBUST", fmt.Sprintf("%d", time.Now().UnixNano())).
+		WithExec([]string{"flux", "get", "kustomization", "-n", namespace}).
+		Stdout(ctx); err != nil {
+		return nil, fmt.Errorf("cannot reach the cluster to verify (namespace %q): %w", namespace, err)
 	}
 
 	deadline := time.Now().Add(time.Duration(parseTimeout(timeout)) * time.Second)


### PR DESCRIPTION
Two things `bootstrap-infra`'s first real run turned up.

## 1. `verify` could not tell a broken kubeconfig from a slow cluster

Every per-component call runs with `Expect: ReturnTypeAny`, so a container that never started counted the same as a Kustomization still reconciling. With an unusable kubeconfig that means: wait out the whole timeout, then name every component as pending.

Measured with a kubeconfig path that did not exist:

```
! bootstrap-infra: not Ready within 3m: cert-manager-install,
  cert-manager-selfsigned, cilium-gateway, cilium-lb, flux-web,
  headlamp, openebs, trust-manager
```

All eight were `Ready=True` at that moment. The actual cause — `failed to read secret file … no such file or directory` — never surfaced, and it sent me looking for a bug in the verify logic instead of at my own argument.

One unfiltered list call before the wait loop separates them:

| | before | after |
|---|---|---|
| broken kubeconfig | 3m wait, blames 8 healthy components | immediate, real message |
| healthy cluster | 8× `Ready=True` | unchanged |

Both verified.

## 2. `ociSource` default bumped to `0.3.34`

That is where six corrected chart versions live (kcl#221). On `0.3.33` the function still renders cert-manager **v1.19.1** over a cluster running **v1.21.1** — and v1.21 is the release that stopped shipping the `serviceaccounts/token` RBAC, so crossing that line silently changes whether a Vault kubernetes-auth ClusterIssuer can sign.

## Context: the rest of the run was clean

Committing to a throwaway branch worked and was faithful — 8 component files plus the source landed, and three spot-checked files were byte-identical to the local render. `main` untouched, probe branch removed.

Part of stuttgart-things#2569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYkrt9hhBe7ei2d6v3Wudv
