### PR TITLE
fix: the auth-mount "already exists" branch could never run

### DIFF
--- a/argocd/create_vault_k8s_auth.go
+++ b/argocd/create_vault_k8s_auth.go
@@ -394,8 +394,15 @@ func (m *Argocd) vaultK8sAuthConfigure(
 	addr := strings.TrimRight(vaultAddr, "/")
 	mountPath := fmt.Sprintf("%s-%s", clusterName, authName)
 	curlBase := `curl -fsS`
+	// Same, WITHOUT -f. The mount check below has to read the response body to
+	// tell "already exists" apart from a real 400 -- and -f makes curl discard
+	// the body entirely, so -o writes no file at all. With -f the idempotent
+	// branch could never run: the grep hit a missing file and the whole step
+	// failed on the second attempt against any cluster whose mount existed.
+	curlSoft := `curl -sS`
 	if skipVerify {
 		curlBase += " -k"
+		curlSoft += " -k"
 	}
 
 	mountPayload, err := json.Marshal(map[string]string{"type": "kubernetes"})
@@ -437,7 +444,7 @@ case "$HTTP" in
   2*) ;;
   400) grep -q "path is already in use" /tmp/mount.out || { cat /tmp/mount.out >&2; exit 1; } ;;
   *)   cat /tmp/mount.out >&2; exit 1 ;;
-esac`, curlBase, string(mountPayload), addr, mountPath)
+esac`, curlSoft, string(mountPayload), addr, mountPath)
 
 	// Upsert backend config. Build the JSON via jq so the multi-line
 	// CA PEM survives shell quoting intact.


### PR DESCRIPTION
`CreateVaultKubernetesAuth` is meant to be idempotent about its Vault mount: `POST /v1/sys/auth/<mount>` returns **HTTP 400** with `path is already in use` when the mount exists, and the script treats that as success.

**It never could.** Every curl in this file is built from

```go
curlBase := `curl -fsS`
```

and `-f` makes curl **discard the response body** on a 4xx — so `-o /tmp/mount.out` writes no file at all. The 400 branch then greps a file that does not exist, falls through to `cat` on the same missing file, and the step exits 1:

```
curl: (22) The requested URL returned error: 400
grep: /tmp/mount.out: No such file or directory
cat: can't open '/tmp/mount.out': No such file or directory
```

So the function worked exactly **once per cluster**. Any second attempt — a pipeline retry, or a re-run after a later phase failed — died on a mount it had created itself and would have been happy to reuse.

## How it surfaced

On `cluster-test2`: the first pipeline run created the mount and the role correctly, then failed at the ClusterIssuer because cert-manager was not installed yet (Flux had not been bootstrapped). Re-running after installing cert-manager failed *here* instead, on the mount, with a message about a missing temp file.

## Fix

The mount check uses a curl without `-f`, so the body survives. Its exit code is not consulted there anyway — only `%{http_code}` is. Every other call keeps `-f`, where failing on a bad status is exactly what we want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYkrt9hhBe7ei2d6v3Wudv
